### PR TITLE
mark as compatible with qgis 4

### DIFF
--- a/cityjson_loader.py
+++ b/cityjson_loader.py
@@ -136,7 +136,7 @@ class CityJsonLoader:
         """Add CityJSON files to the file list"""
         self.reset_progress_format_on_ui_change()
         for filename in filepaths:
-            existing_items = self.dlg.listWidget.findItems(filename, Qt.MatchExactly)
+            existing_items = self.dlg.listWidget.findItems(filename, Qt.MatchFlag.MatchExactly)
             if not existing_items:
                 self.dlg.listWidget.addItem(filename)
                 epsg = self.load_file_crs(filename)

--- a/metadata.txt
+++ b/metadata.txt
@@ -9,6 +9,7 @@
 [general]
 name=CityJSON Loader
 qgisMinimumVersion=3.0
+qgisMaximumVersion=4.99
 description=This plugin allows for CityJSON files to be loaded in QGIS
 version=0.8.2
 author=3D geoinformation group (TU Delft)


### PR DESCRIPTION
that's enough for the plugin to show as compatible in the extensions manager, and i've been able to open the dialog, thanks to all the fixes in #70